### PR TITLE
make rulerAPIPath configurable

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -35,6 +35,7 @@ type Config struct {
 	TLS             tls.ClientConfig
 	UseLegacyRoutes bool   `yaml:"use_legacy_routes"`
 	AuthToken       string `yaml:"auth_token"`
+	RulerAPIPath    string `yaml:"ruler_api_path"`
 }
 
 // CortexClient is used to get and load rules into a cortex ruler
@@ -82,6 +83,9 @@ func New(cfg Config) (*CortexClient, error) {
 	}
 
 	path := rulerAPIPath
+	if cfg.RulerAPIPath != "" {
+		path = cfg.RulerAPIPath
+	}
 	if cfg.UseLegacyRoutes {
 		path = legacyAPIPath
 	}

--- a/pkg/commands/rules.go
+++ b/pkg/commands/rules.go
@@ -142,6 +142,11 @@ func (r *RuleCommand) Register(app *kingpin.Application) {
 			Envar("CORTEX_USE_LEGACY_ROUTES").
 			BoolVar(&r.ClientConfig.UseLegacyRoutes)
 
+		c.Flag("ruler-api-path", "if set, API requests to cortex will use an alternative path for the ruler API, alternatively set CORTEX_RULER_API_PATH. The default is /api/v1/rules").
+			Default("").
+			Envar("CORTEX_RULER_API_PATH").
+			StringVar(&r.ClientConfig.RulerAPIPath)
+
 		c.Flag("tls-ca-path", "TLS CA certificate to verify cortex API as part of mTLS, alternatively set CORTEX_TLS_CA_PATH.").
 			Default("").
 			Envar("CORTEX_TLS_CA_CERT").


### PR DESCRIPTION
Currently the ruler api path is hardcoded in cortex-tools. In some deployments the ruler api is available on a different path though. This PR makes the `rulerAPIPath` configurable