### PR TITLE
Refactor Makefile and update versions in Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ cmd/chunktool/chunktool
 cmd/logtool/logtool
 cmd/rules-migrator/rules-migrator
 cmd/e2ealerting/e2ealerting
+cmd/blockscopy/blockscopy
+cmd/benchtool/benchtool
+cmd/deserializer/deserializer
+cmd/blockgen/blockgen
+cmd/sim/sim
 .uptodate
 .pkg
 .cache
@@ -13,3 +18,4 @@ dist/
 /metrics-in-grafana.json
 /prometheus-metrics.json
 /metrics-in-ruler.json
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
 ## unreleased/master
 * [CHANGE] Upgrade to v1.13.2
+* [CHANGE] Updates version of Go to 1.22 and Alpine to 3.19.1 in Dockerfiles
 * [FEATURE] Make rulerAPI Path configurable
 * [FEATURE] Add tool to deserialize alertmanager state file
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -3,10 +3,10 @@ ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir
 ENV GOPROXY=https://proxy.golang.org
-RUN make clean && make cortextool
+RUN make clean && make {{APP_NAME}}
 
 FROM alpine:3.19.1
 RUN apk add --update --no-cache ca-certificates
-COPY --from=build /build_dir/cmd/cortextool/cortextool /usr/bin/cortextool
+COPY --from=build /build_dir/cmd/{{APP_NAME}}/{{APP_NAME}} /usr/bin/{{APP_NAME}}
 EXPOSE 80
-ENTRYPOINT [ "/usr/bin/cortextool" ]
+ENTRYPOINT [ "/usr/bin/{{APP_NAME}}" ]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all images lint test clean cross
+.PHONY: all images lint test clean cross dockerfiles run-images $(APP_NAMES)
 
 .DEFAULT_GOAL := all
 IMAGE_PREFIX ?= cortexproject
@@ -6,90 +6,41 @@ IMAGE_TAG := $(shell ./tools/image-tag)
 GIT_REVISION := $(shell git rev-parse --short HEAD)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 GO_FLAGS := -mod=vendor -ldflags "-extldflags \"-static\" -s -w -X $(VPREFIX).Branch=$(GIT_BRANCH) -X $(VPREFIX).Version=$(IMAGE_TAG) -X $(VPREFIX).Revision=$(GIT_REVISION)" -tags netgo
+APP_NAMES := benchtool blockgen blockscopy chunktool cortextool deserializer e2ealerting logtool rules-migrator sim
 
-all: cortextool chunktool logtool
-images: cortextool-image chunktool-image logtool-image benchtool-image
-benchtool: cmd/benchtool/benchtool
-cortextool: cmd/cortextool/cortextool
-chunktool: cmd/chunktool/chunktool
-logtool: cmd/logtool/logtool
-e2ealerting: cmd/e2ealerting/e2ealerting
-blockscopy: cmd/blockscopy/blockscopy
-deserializer: cmd/deserializer/deserializer
+all: $(APP_NAMES)
+images: $(addsuffix -image, $(APP_NAMES))
 
-benchtool-image:
-	$(SUDO) docker build -t $(IMAGE_PREFIX)/benchtool -f cmd/benchtool/Dockerfile .
-	$(SUDO) docker tag $(IMAGE_PREFIX)/benchtool $(IMAGE_PREFIX)/benchtool:$(IMAGE_TAG)
+%-image:
+	$(SUDO) docker build -t $(IMAGE_PREFIX)/$* -f cmd/$*/Dockerfile .
+	$(SUDO) docker tag $(IMAGE_PREFIX)/$* $(IMAGE_PREFIX)/$*:$(IMAGE_TAG)
 
-cortextool-image:
-	$(SUDO) docker build -t $(IMAGE_PREFIX)/cortextool -f cmd/cortextool/Dockerfile .
-	$(SUDO) docker tag $(IMAGE_PREFIX)/cortextool $(IMAGE_PREFIX)/cortextool:$(IMAGE_TAG)
+$(APP_NAMES): %: $(shell find cmd/$* -name '*.go')
+	CGO_ENABLED=0 go build $(GO_FLAGS) -o ./cmd/$@ ./cmd/$*
 
-chunktool-image:
-	$(SUDO) docker build -t $(IMAGE_PREFIX)/chunktool -f cmd/chunktool/Dockerfile .
-	$(SUDO) docker tag $(IMAGE_PREFIX)/chunktool $(IMAGE_PREFIX)/chunktool:$(IMAGE_TAG)
+dockerfiles: Dockerfile.template
+	for app in $(APP_NAMES); do \
+		sed "s/{{APP_NAME}}/$$app/g" Dockerfile.template > cmd/$$app/Dockerfile; \
+	done
 
-logtool-image:
-	$(SUDO) docker build -t $(IMAGE_PREFIX)/logtool -f cmd/logtool/Dockerfile .
-	$(SUDO) docker tag $(IMAGE_PREFIX)/logtool $(IMAGE_PREFIX)/logtool:$(IMAGE_TAG)
-
-e2ealerting-image:
-	$(SUDO) docker build -t $(IMAGE_PREFIX)/e2ealerting -f cmd/e2ealerting/Dockerfile .
-	$(SUDO) docker tag $(IMAGE_PREFIX)/e2ealerting $(IMAGE_PREFIX)/e2ealerting:$(IMAGE_TAG)
-push-e2ealerting-image: e2ealerting-image
-	$(SUDO) docker push $(IMAGE_PREFIX)/e2ealerting:$(IMAGE_TAG)
-
-blockscopy-image:
-	$(SUDO) docker build -t $(IMAGE_PREFIX)/blockscopy -f cmd/blockscopy/Dockerfile .
-	$(SUDO) docker tag $(IMAGE_PREFIX)/blockscopy $(IMAGE_PREFIX)/blockscopy:$(IMAGE_TAG)
-
-cmd/benchtool/benchtool: $(APP_GO_FILES) cmd/benchtool/main.go
-	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
-
-cmd/cortextool/cortextool: $(APP_GO_FILES) cmd/cortextool/main.go
-	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
-
-cmd/chunktool/chunktool: $(APP_GO_FILES) cmd/chunktool/main.go
-	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
-
-cmd/logtool/logtool: $(APP_GO_FILES) cmd/logtool/main.go
-	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
-
-cmd/e2ealerting/e2ealerting: $(APP_GO_FILES) cmd/e2ealerting/main.go
-	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
-
-cmd/rules-migrator/rules-migrator: $(APP_GO_FILES) cmd/rules-migrator/main.go
-	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
-
-cmd/blockscopy/blockscopy: $(APP_GO_FILES) cmd/blockscopy/main.go
-	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
-
-cmd/deserializer/deserializer: $(APP_GO_FILES) cmd/deserializer/main.go
-	CGO_ENABLED=0 go build $(GO_FLAGS) -o $@ ./$(@D)
+run-images:
+	for app in $(APP_NAMES); do \
+		$(SUDO) docker run --rm $(IMAGE_PREFIX)/$$app:$(IMAGE_TAG) --help; \
+	done
 
 lint:
 	golangci-lint run -v
 
 cross:
-	CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64" -os="linux windows darwin" -osarch="darwin/arm64" ./cmd/benchtool
-	CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64" -os="linux windows darwin" -osarch="darwin/arm64" ./cmd/blockgen
-	CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64" -os="linux windows darwin" -osarch="darwin/arm64" ./cmd/blockscopy
-	CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64" -os="linux windows darwin" -osarch="darwin/arm64" ./cmd/chunktool
-	CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64" -os="linux windows darwin" -osarch="darwin/arm64" ./cmd/cortextool
-	CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64" -os="linux windows darwin" -osarch="darwin/arm64" ./cmd/e2ealerting
-	CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64" -os="linux windows darwin" -osarch="darwin/arm64" ./cmd/logtool
-	CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64" -os="linux windows darwin" -osarch="darwin/arm64" ./cmd/rules-migrator
-	CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64" -os="linux windows darwin" -osarch="darwin/arm64" ./cmd/sim
-	CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64" -os="linux windows darwin" -osarch="darwin/arm64" ./cmd/deserializer
+	for app in $(APP_NAMES); do \
+		CGO_ENABLED=0 gox -output="dist/{{.Dir}}-{{.OS}}-{{.Arch}}" -ldflags=${LDFLAGS} -arch="amd64" -os="linux windows darwin" -osarch="darwin/arm64" ./cmd/$$app; \
+	done
 
 test:
 	go test -mod=vendor -p=8 ./pkg/...
 
 clean:
-	rm -rf cmd/benchtool/benchtool
-	rm -rf cmd/cortextool/cortextool
-	rm -rf cmd/chunktool/chunktool
-	rm -rf cmd/logtool/logtool
-	rm -rf cmd/e2ealerting/e2ealerting
-	rm -rf cmd/blockscopy/blockscopy
-	rm -rf cmd/deserializer/deserializer
+	for app in $(APP_NAMES); do \
+		 rm -f cmd/$$app/$$app; \
+	done
+	rm -rf dist

--- a/cmd/benchtool/Dockerfile
+++ b/cmd/benchtool/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.16.15-stretch as build
+FROM golang:1.22.2-bookworm as build
 ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir
 ENV GOPROXY=https://proxy.golang.org
 RUN make clean && make benchtool
 
-FROM       alpine:3.14
-RUN        apk add --update --no-cache ca-certificates
-COPY       --from=build /build_dir/cmd/benchtool/benchtool /usr/bin/benchtool
-EXPOSE     80
+FROM alpine:3.19.1
+RUN apk add --update --no-cache ca-certificates
+COPY --from=build /build_dir/cmd/benchtool/benchtool /usr/bin/benchtool
+EXPOSE 80
 ENTRYPOINT [ "/usr/bin/benchtool" ]

--- a/cmd/blockgen/Dockerfile
+++ b/cmd/blockgen/Dockerfile
@@ -3,10 +3,10 @@ ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir
 ENV GOPROXY=https://proxy.golang.org
-RUN make clean && make cortextool
+RUN make clean && make blockgen
 
 FROM alpine:3.19.1
 RUN apk add --update --no-cache ca-certificates
-COPY --from=build /build_dir/cmd/cortextool/cortextool /usr/bin/cortextool
+COPY --from=build /build_dir/cmd/blockgen/blockgen /usr/bin/blockgen
 EXPOSE 80
-ENTRYPOINT [ "/usr/bin/cortextool" ]
+ENTRYPOINT [ "/usr/bin/blockgen" ]

--- a/cmd/blockscopy/Dockerfile
+++ b/cmd/blockscopy/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.16.15-stretch as build
+FROM golang:1.22.2-bookworm as build
 ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir
 ENV GOPROXY=https://proxy.golang.org
 RUN make clean && make blockscopy
 
-FROM       alpine:3.14
-RUN        apk add --update --no-cache ca-certificates
-COPY       --from=build /build_dir/cmd/blockscopy/blockscopy /usr/bin/blockscopy
-EXPOSE     80
+FROM alpine:3.19.1
+RUN apk add --update --no-cache ca-certificates
+COPY --from=build /build_dir/cmd/blockscopy/blockscopy /usr/bin/blockscopy
+EXPOSE 80
 ENTRYPOINT [ "/usr/bin/blockscopy" ]

--- a/cmd/chunktool/Dockerfile
+++ b/cmd/chunktool/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.16.15-stretch as build
+FROM golang:1.22.2-bookworm as build
 ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir
 ENV GOPROXY=https://proxy.golang.org
 RUN make clean && make chunktool
 
-FROM       alpine:3.14
-RUN        apk add --update --no-cache ca-certificates
-COPY       --from=build /build_dir/cmd/chunktool/chunktool /usr/bin/chunktool
-EXPOSE     80
+FROM alpine:3.19.1
+RUN apk add --update --no-cache ca-certificates
+COPY --from=build /build_dir/cmd/chunktool/chunktool /usr/bin/chunktool
+EXPOSE 80
 ENTRYPOINT [ "/usr/bin/chunktool" ]

--- a/cmd/deserializer/Dockerfile
+++ b/cmd/deserializer/Dockerfile
@@ -3,10 +3,10 @@ ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir
 ENV GOPROXY=https://proxy.golang.org
-RUN make clean && make cortextool
+RUN make clean && make deserializer
 
 FROM alpine:3.19.1
 RUN apk add --update --no-cache ca-certificates
-COPY --from=build /build_dir/cmd/cortextool/cortextool /usr/bin/cortextool
+COPY --from=build /build_dir/cmd/deserializer/deserializer /usr/bin/deserializer
 EXPOSE 80
-ENTRYPOINT [ "/usr/bin/cortextool" ]
+ENTRYPOINT [ "/usr/bin/deserializer" ]

--- a/cmd/e2ealerting/Dockerfile
+++ b/cmd/e2ealerting/Dockerfile
@@ -1,11 +1,12 @@
-FROM golang:1.16.15-stretch as build
+FROM golang:1.22.2-bookworm as build
 ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir
+ENV GOPROXY=https://proxy.golang.org
 RUN make clean && make e2ealerting
 
-FROM       alpine:3.14
-RUN        apk add --update --no-cache ca-certificates
-COPY       --from=build /build_dir/cmd/e2ealerting/e2ealerting /usr/bin/e2ealerting
-EXPOSE     80
+FROM alpine:3.19.1
+RUN apk add --update --no-cache ca-certificates
+COPY --from=build /build_dir/cmd/e2ealerting/e2ealerting /usr/bin/e2ealerting
+EXPOSE 80
 ENTRYPOINT [ "/usr/bin/e2ealerting" ]

--- a/cmd/logtool/Dockerfile
+++ b/cmd/logtool/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.16.15-stretch as build
+FROM golang:1.22.2-bookworm as build
 ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir
 ENV GOPROXY=https://proxy.golang.org
 RUN make clean && make logtool
 
-FROM       alpine:3.14
-RUN        apk add --update --no-cache ca-certificates
-COPY       --from=build /build_dir/cmd/logtool/logtool /usr/bin/logtool
-EXPOSE     80
+FROM alpine:3.19.1
+RUN apk add --update --no-cache ca-certificates
+COPY --from=build /build_dir/cmd/logtool/logtool /usr/bin/logtool
+EXPOSE 80
 ENTRYPOINT [ "/usr/bin/logtool" ]

--- a/cmd/rules-migrator/Dockerfile
+++ b/cmd/rules-migrator/Dockerfile
@@ -3,10 +3,10 @@ ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir
 ENV GOPROXY=https://proxy.golang.org
-RUN make clean && make cortextool
+RUN make clean && make rules-migrator
 
 FROM alpine:3.19.1
 RUN apk add --update --no-cache ca-certificates
-COPY --from=build /build_dir/cmd/cortextool/cortextool /usr/bin/cortextool
+COPY --from=build /build_dir/cmd/rules-migrator/rules-migrator /usr/bin/rules-migrator
 EXPOSE 80
-ENTRYPOINT [ "/usr/bin/cortextool" ]
+ENTRYPOINT [ "/usr/bin/rules-migrator" ]

--- a/cmd/sim/Dockerfile
+++ b/cmd/sim/Dockerfile
@@ -3,10 +3,10 @@ ARG GOARCH="amd64"
 COPY . /build_dir
 WORKDIR /build_dir
 ENV GOPROXY=https://proxy.golang.org
-RUN make clean && make cortextool
+RUN make clean && make sim
 
 FROM alpine:3.19.1
 RUN apk add --update --no-cache ca-certificates
-COPY --from=build /build_dir/cmd/cortextool/cortextool /usr/bin/cortextool
+COPY --from=build /build_dir/cmd/sim/sim /usr/bin/sim
 EXPOSE 80
-ENTRYPOINT [ "/usr/bin/cortextool" ]
+ENTRYPOINT [ "/usr/bin/sim" ]


### PR DESCRIPTION
- refactors Makefile to generate Dockerfiles with Dockerfile.template
- updates version of Go to 1.22 and alpine to 3.19.1 in Dockerfiles
- adds new Dockerfiles for sim, blockgen, deserializer, and rules-migrator commands
- update .gitignore to ignore new commands