### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -4,6 +4,8 @@ on:
     paths-ignore:
       - "docs/**"
       - "*.md"
+permissions:
+  contents: read
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Potential fix for [https://github.com/cortexproject/cortex-tools/security/code-scanning/3](https://github.com/cortexproject/cortex-tools/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/validate_pr.yml` so all jobs inherit the minimum required `GITHUB_TOKEN` scope.  
Best single fix (no behavior change): define:

- `permissions:`
  - `contents: read`

Place this at the workflow root (after `on` block and before `jobs`), which applies to all jobs unless overridden. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
