### PR TITLE
Upgrade goreleaser config to v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,7 +76,25 @@ builds:
       - amd64
       - 386
 archives:
-  - name_template: >-
+  - id: cortextool
+    ids:
+      - cortextool-darwin
+      - cortextool-linux
+      - cortextool-windows
+    name_template: >-
+      {{ .Binary }}_{{ .Version }}_{{ if eq .Os "darwin" }}mac-os{{ else }}{{ .Os }}{{ end }}_{{ if eq .Arch "amd64" }}x86_64{{ else if eq .Arch "386" }}i386{{ else }}{{ .Arch }}{{ end }}
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - none*
+    formats: [binary]
+  - id: benchtool
+    ids:
+      - benchtool-darwin
+      - benchtool-linux
+      - benchtool-windows
+    name_template: >-
       {{ .Binary }}_{{ .Version }}_{{ if eq .Os "darwin" }}mac-os{{ else }}{{ .Os }}{{ end }}_{{ if eq .Arch "amd64" }}x86_64{{ else if eq .Arch "386" }}i386{{ else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,8 +1,7 @@
 version: 2
 before:
   hooks:
-    - go mod download
-    - go generate ./...
+    - go mod verify
 project_name: cortextool
 builds:
   - id: cortextool-darwin
@@ -11,6 +10,8 @@ builds:
     binary: cortextool
     env:
       - CGO_ENABLED=0
+    flags:
+      - -mod=vendor
     main: ./cmd/cortextool/main.go
     goos:
       - darwin
@@ -23,6 +24,8 @@ builds:
     binary: cortextool
     env:
       - CGO_ENABLED=0
+    flags:
+      - -mod=vendor
     main: ./cmd/cortextool/main.go
     goos:
       - linux
@@ -34,6 +37,8 @@ builds:
     binary: cortextool
     env:
       - CGO_ENABLED=0
+    flags:
+      - -mod=vendor
     main: ./cmd/cortextool/main.go
     goos:
       - windows
@@ -46,6 +51,8 @@ builds:
     binary: benchtool
     env:
       - CGO_ENABLED=0
+    flags:
+      - -mod=vendor
     main: ./cmd/benchtool/
     goos:
       - darwin
@@ -58,6 +65,8 @@ builds:
     binary: benchtool
     env:
       - CGO_ENABLED=0
+    flags:
+      - -mod=vendor
     main: ./cmd/benchtool/
     goos:
       - linux
@@ -69,6 +78,8 @@ builds:
     binary: benchtool
     env:
       - CGO_ENABLED=0
+    flags:
+      - -mod=vendor
     main: ./cmd/benchtool/
     goos:
       - windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
+version: 2
 before:
   hooks:
     - go mod download
-    # you may remove this if you don't need go generate
     - go generate ./...
 project_name: cortextool
 builds:
@@ -76,22 +76,18 @@ builds:
       - amd64
       - 386
 archives:
-  - replacements:
-      darwin: mac-os
-      linux: linux
-      windows: windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .Binary }}_{{ .Version }}_{{ if eq .Os "darwin" }}mac-os{{ else }}{{ .Os }}{{ end }}_{{ if eq .Arch "amd64" }}x86_64{{ else if eq .Arch "386" }}i386{{ else }}{{ .Arch }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     files:
       - none*
-    format: binary
+    formats: [binary]
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:
@@ -99,9 +95,7 @@ changelog:
       - '^docs:'
       - '^test:'
 dockers:
-  - goos: linux
-    goarch: amd64
-    ids:
+  - ids:
       - cortextool-linux
     dockerfile: cmd/cortextool/GR.Dockerfile
     image_templates:
@@ -114,9 +108,7 @@ dockers:
     - "--label=org.opencontainers.image.version={{.Version}}"
     - "--label=repository=https://github.com/cortexproject/cortex-tools"
     - "--label=homepage=https://cortexmetrics.io"
-  - goos: linux
-    goarch: amd64
-    ids:
+  - ids:
       - benchtool-linux
     dockerfile: cmd/benchtool/GR.Dockerfile
     image_templates:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ $ git tag -s "${tag}" -m "${tag}"
 $ git push origin "${tag}"
 ```
 
-3. Run `$ goreleaser release --release-notes=changelogs/v0.3.0.md --rm-dist` where the changelog file is the one created as part of step 1.
+3. Run `$ goreleaser release --release-notes=changelogs/v0.3.0.md --clean` where the changelog file is the one created as part of step 1.
 4. The docker image will be pushed automatically.
 
 


### PR DESCRIPTION
## Summary
- Upgrade `.goreleaser.yml` from v1 to v2 format
- Replace deprecated `archives.replacements` with `name_template`
- Replace deprecated `archives.format` with `archives.formats`
- Remove `dockers.goos`/`dockers.goarch` (inferred from build IDs in v2)
- Replace `snapshot.name_template` with `snapshot.version_template`
- Update `RELEASE.md` to use `--clean` instead of deprecated `--rm-dist`

## Test plan
- [x] `goreleaser check` passes
- [x] `goreleaser release --snapshot --clean` produces correct artifact names matching previous releases
