### PR TITLE
Prepare release v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Order should be `CHANGE`, `FEATURE`, `ENHANCEMENT`, and `BUGFIX`
 
+## v0.21.1
+* [BUGFIX] Fix `rules lint`/`prepare`/`check` failing with "cortex address is required" #61
+
 ## v0.21.0
 * [CHANGE] Upgrade cortex to v1.21.0
 * [CHANGE] Upgrade Go to 1.25

--- a/changelogs/v0.21.1.md
+++ b/changelogs/v0.21.1.md
@@ -1,0 +1,33 @@
+# v0.21.1 Release
+
+## Changes
+
+* [BUGFIX] Fix `rules lint`/`prepare`/`check` failing with "cortex address is required" #61
+
+## Installation
+
+## cortextool
+
+```console
+# download the binary (adapt os and arch as needed)
+$ curl -fSL -o "cortextool" "https://github.com/cortexproject/cortex-tools/releases/download/v0.21.1/cortextool_0.21.1_linux_x86_64"
+
+# make it executable
+$ chmod a+x "cortextool"
+
+# have fun :)
+$ ./cortextool --help
+```
+
+## benchtool
+
+```console
+# download the binary (adapt os and arch as needed)
+$ curl -fSL -o "benchtool" "https://github.com/cortexproject/cortex-tools/releases/download/v0.21.1/benchtool_0.21.1_linux_x86_64"
+
+# make it executable
+$ chmod a+x "benchtool"
+
+# have fun :)
+$ ./benchtool --help
+```


### PR DESCRIPTION
Adds CHANGELOG entry and changelogs/v0.21.1.md for the v0.21.1 
  patch release containing the fix from #61.